### PR TITLE
Make the TensorFlow dependency an 'extra'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,12 @@ rm-venv:
 
 install:
 	$(POETRY) update
-	$(POETRY) install
+	$(POETRY) install --extras=tensorflow
+	$(POETRY) run pip install -r .readthedocs-requirements.txt
+
+install-gpu:
+	$(POETRY) update
+	$(POETRY) install --extras=tensorflow-gpu
 	$(POETRY) run pip install -r .readthedocs-requirements.txt
 
 fmt:

--- a/README.rst
+++ b/README.rst
@@ -29,11 +29,21 @@ Installation
 ------------
 
 ScalarStop is `available on PyPI <https://pypi.org/project/scalarstop/>`_.
-You can install by running the command:
+
+If you are using TensorFlow on a CPU, you can install ScalarStop with the command:
 
 .. code:: bash
 
-    python3 -m pip install scalarstop
+    python3 -m pip install scalarstop[tensorflow]
+
+If you are using TensorFlow with GPUs, you can install ScalarStop with the command:
+
+.. code:: bash
+
+    python3 -m pip install scalarstop[tensorflow-gpu]
+
+Development
+-----------
 
 If you would like to make changes to ScalarStop, you can `clone the repository <https://github.com/scalarstop/scalarstop>`_
 from GitHub.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -58,11 +58,21 @@ Installation
 ^^^^^^^^^^^^
 
 ScalarStop is `available on PyPI <https://pypi.org/project/scalarstop/>`_.
-You can install by running the command:
+
+If you are using TensorFlow on a CPU, you can install ScalarStop with the command:
 
 .. code:: bash
 
-    python3 -m pip install scalarstop
+    python3 -m pip install scalarstop[tensorflow]
+
+If you are using TensorFlow with GPUs, you can install ScalarStop with the command:
+
+.. code:: bash
+
+    python3 -m pip install scalarstop[tensorflow-gpu]
+
+Development
+-----------
 
 If you would like to make changes to ScalarStop, you can `clone the repository <https://github.com/scalarstop/scalarstop>`_
 from GitHub.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,12 +10,16 @@ repository = "https://github.com/scalarstop/scalarstop"
 
 [tool.poetry.dependencies]
 python = "^3.8"
-tensorflow = ">=2.3.0"
 pandas = "*"
 numpy = "*"
 cloudpickle = "^1.6.0"
 SQLAlchemy = "^1.4.5"
 psycopg2-binary = "^2.8.6"
+
+# These are optional dependencies installed
+# with pip extras. Seee the `tool.poetry.extras` section for more.
+tensorflow = { version = ">=2.3.0", optional = true }
+tensorflow-gpu = { version = ">=2.3.0", optional = true }
 
 [tool.poetry.dev-dependencies]
 # dev-dependencies does not include dependencies
@@ -27,6 +31,12 @@ pylint = "^2.7.4"
 mypy = "^0.812"
 coverage = "^5.5"
 jupyter = "^1.0.0"
+
+# We use pip "extras" to enforce a dependency on either
+# the `tensorflow` or `tensorflow-gpu` package.
+[tool.poetry.extras]
+tensorflow = ["tensorflow"]
+tensorflow-gpu = ["tensorflow-gpu"]
 
 [tool.black]
 target-version = ['py38']
@@ -53,6 +63,7 @@ exclude = '''
   )/
 )
 '''
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
This makes it easier to use ScalarStop with either the
`tensorflow` or `tensorflow-gpu` pip package.