### PR TITLE
Standardize how we hash ModelTemplates and DataBlobs

### DIFF
--- a/scalarstop/_single_namespace.py
+++ b/scalarstop/_single_namespace.py
@@ -1,0 +1,67 @@
+"""Common utilities for classes that manage hyperparameters."""
+from typing import Any, Mapping, Optional, Type, Union
+
+from scalarstop.hyperparams import HyperparamsType, hash_hyperparams, init_hyperparams
+
+
+class SingleNamespace:
+    """
+    A common base class for classes with hyperparameters.
+
+    Subclasses of this class takes hyperparameters of
+    :py:class:`~scalarstop.hyperparams.HyperparamsType` and calculates
+    hash-based names of the hyperparameters.
+    """
+
+    Hyperparams: Type[HyperparamsType] = HyperparamsType
+    hyperparams: HyperparamsType
+
+    _group_name: str = ""
+    _name: str = ""
+
+    def __init__(
+        self,
+        *,
+        hyperparams: Optional[Union[Mapping[str, Any], HyperparamsType]] = None,
+        **kwargs,  # pylint: disable=unused-argument
+    ):
+        """
+        Args:
+            hyperparams: The hyperparameters to initialize this class with.
+        """
+        self.hyperparams = init_hyperparams(
+            class_name=self.__class__.__name__,
+            hyperparams=hyperparams,
+            hyperparams_class=self.Hyperparams,
+        )
+
+    @classmethod
+    def calculate_name(
+        cls, *, hyperparams: Optional[Union[Mapping[str, Any], HyperparamsType]] = None
+    ) -> str:
+        """
+        The hashed name of this object, given the hyperparameters.
+
+        This classmethod can be used to calculate what an object would
+        be without actually having to call ``__init__()``.
+        """
+        hp = init_hyperparams(
+            class_name=cls.__name__,
+            hyperparams=hyperparams,
+            hyperparams_class=cls.Hyperparams,
+        )
+        return "-".join((cls.__name__, hash_hyperparams(hp)))
+
+    @property
+    def group_name(self) -> str:
+        """The "group" name is this object's Python class name."""
+        if not self._group_name:
+            self._group_name = self.__class__.__name__
+        return self._group_name
+
+    @property
+    def name(self) -> str:
+        """The group (class) name and a calculated hash of the hyperparameters."""
+        if not self._name:
+            self._name = self.calculate_name(hyperparams=self.hyperparams)
+        return self._name

--- a/scalarstop/model.py
+++ b/scalarstop/model.py
@@ -234,13 +234,13 @@ class Model:
             self._model = self._model_template.new_model()
         else:
             self._model = model
-        self._name = self._make_name(
+        self._name = self.calculate_name(
             datablob_name=self._datablob.name,
             model_template_name=self._model_template.name,
         )
 
     @staticmethod
-    def _make_name(*, model_template_name: str, datablob_name: str) -> str:
+    def calculate_name(*, model_template_name: str, datablob_name: str) -> str:
         """
         Create a model name from a
         :py:class:`~scalarstop.ModelTemplate`
@@ -435,7 +435,7 @@ class KerasModel(Model):
         model_template: ModelTemplate,
         models_directory: str,
     ) -> "KerasModel":
-        model_name = cls._make_name(
+        model_name = cls.calculate_name(
             datablob_name=datablob.name, model_template_name=model_template.name
         )
         model_path = os.path.join(models_directory, model_name)

--- a/scalarstop/model_template.py
+++ b/scalarstop/model_template.py
@@ -49,66 +49,19 @@ instance of a machine learning model created from your
 'small_dense_10_way_classifier_v1-zc9r3do1baeeffafanjnjmou'
 
 """
-from typing import Any, Mapping, Optional, Union
+from typing import Any
 
+from scalarstop._single_namespace import SingleNamespace
 from scalarstop.exceptions import IsNotImplemented
-from scalarstop.hyperparams import HyperparamsType, hash_hyperparams, init_hyperparams
 
 
-class ModelTemplate:
+class ModelTemplate(SingleNamespace):
     """Describes machine learning model architectures and hyperparameters. Used to generate new machine learning model objects that are passed into :py:class:`~scalarstop.model.Model` objects."""  # pylint: disable=line-too-long
 
-    Hyperparams: type
-    hyperparams: HyperparamsType
-
-    _name: Optional[str] = None
-    _group_name: Optional[str] = None
     _model = None
-
-    def __init__(
-        self, *, hyperparams: Optional[Union[Mapping[str, Any], HyperparamsType]] = None
-    ):
-        self.hyperparams = init_hyperparams(
-            class_name=self.__class__.__name__,
-            hyperparams=hyperparams,
-            hyperparams_class=self.Hyperparams,
-        )
 
     def __repr__(self) -> str:
         return f"<sp.ModelTemplate {self.name}>"
-
-    @property
-    def name(self) -> str:
-        """
-        The name of the specific model with values as hyperparameters.
-
-        If you intend on overriding this method, make sure that
-        instances of the same class with different hyperparameters
-        will have different names.
-
-        However, if you use additional parameters to your
-        :py:class:`~scalarstop.model_template.ModelTemplate` 's
-        ``__init__()`` method that are
-        *not* hyperparameters--such as paths on your filesystem--then
-        you should be sure that changes in those values do *not*
-        change your :py:class:`ModelTemplate` name.
-        """
-        if self._name is None:
-            self._name = "-".join((self.group_name, hash_hyperparams(self.hyperparams)))
-        return self._name
-
-    @property
-    def group_name(self) -> str:
-        """
-        The group name of this model template.
-
-        Conceptually, the group name is the name for all compiled machine
-        learning models that share the same code but have different
-        hyperparameters.
-        """
-        if self._group_name is None:
-            self._group_name = self.__class__.__name__
-        return self._group_name
 
     def new_model(self) -> Any:
         """


### PR DESCRIPTION
The naming and hashing logic for a ModelTemplate and a DataBlob
are identical, so let's combine their code.

We also provide the `calculate_name()` classmethod to make
it easier to calculate the name of an object without
having to initialize it.