### PR TITLE
Enable DataBlob operations like batch(), cache() to be selective on whether they only appply to the training, validation, or test sets

### DIFF
--- a/scalarstop/datablob.py
+++ b/scalarstop/datablob.py
@@ -438,7 +438,7 @@ class DataBlob(SingleNamespace):
 
             validation: Apply the options to the validation set. Defaults to ``True``.
 
-            Test: Apply the options to the test set. Defaults to ``True``.
+            test: Apply the options to the test set. Defaults to ``True``.
         """
         return _WithOptionsDataBlob(
             wraps=self,

--- a/scalarstop/exceptions.py
+++ b/scalarstop/exceptions.py
@@ -13,6 +13,15 @@ class ScalarStopException(Exception):
     """
 
 
+class InconsistentCachingParameters(ValueError, ScalarStopException):
+    """
+    Raised when DataBlob.cache() is set with inconsistent parameters.
+
+    An example of setting inconsistent parameters is when the user says
+    ``training=False`` and ``preload_training=True``.
+    """
+
+
 class YouForgotTheHyperparams(ValueError, ScalarStopException):
     """Raised when the user creates a class, but forgets to add a nested Hyperparams class."""
 

--- a/tests/assertions.py
+++ b/tests/assertions.py
@@ -14,6 +14,17 @@ _TESTCASE = unittest.TestCase()
 assert_equal = _TESTCASE.assertEqual
 
 
+def tfdata_get_first(tfdata: tf.data.Dataset) -> tf.Tensor:
+    """Get the first element in a tf.data.Dataset."""
+    for first in tfdata.take(1):
+        return first
+
+
+def tfdata_get_first_shape_len(tfdata: tf.data.Dataset) -> int:
+    """Get the length of the TensorShape of the first element in a tf.data.Dataset."""
+    return len(tfdata_get_first(tfdata).shape)
+
+
 def assert_directory(dirname: str, expected_filenames: List[str]):
     """Assert the contents of an arbitrary directory on disk."""
     actual_filenames = os.listdir(dirname)


### PR DESCRIPTION
Oftentimes, we do not want every operation to apply to every tf.data pipeline we are managing.