### PR TITLE
Remove the WrongHyperparamsKeys exception

### DIFF
--- a/scalarstop/exceptions.py
+++ b/scalarstop/exceptions.py
@@ -46,18 +46,6 @@ class WrongHyperparamsType(TypeError, ScalarStopException):
         )
 
 
-class WrongHyperparamsKeys(TypeError, ScalarStopException):
-    """Raised when the user has passed extra or missing keys for constructing hyperparams."""
-
-    def __init__(self, hyperparams: Any, hyperparams_class: type):
-        hyperparams_class_fields = [field.name for field in fields(hyperparams_class)]
-        super().__init__(
-            "Wrong keys passed to create hyperparams. "
-            f"Valid keys include {hyperparams_class_fields}. "
-            f"The object you passed is: {hyperparams}"
-        )
-
-
 class DataBlobNotFound(FileNotFoundError, ScalarStopException):
     """
     Raised when we cannot load a :py:class:`DataBlob`

--- a/scalarstop/hyperparams.py
+++ b/scalarstop/hyperparams.py
@@ -5,11 +5,7 @@ from typing import TYPE_CHECKING, Any, Dict, Mapping
 
 from scalarstop._naming import hash_id
 from scalarstop.dataclasses import asdict, is_dataclass
-from scalarstop.exceptions import (
-    WrongHyperparamsKeys,
-    WrongHyperparamsType,
-    YouForgotTheHyperparams,
-)
+from scalarstop.exceptions import WrongHyperparamsType, YouForgotTheHyperparams
 
 if TYPE_CHECKING:
     from dataclasses import dataclass
@@ -40,21 +36,11 @@ def init_hyperparams(*, class_name: str, hyperparams, hyperparams_class) -> Any:
     """
     if isinstance(hyperparams_class, type) and is_dataclass(hyperparams_class):
         if hyperparams is None:
-            try:
-                return hyperparams_class()
-            except (TypeError, ValueError, SyntaxError) as exc:
-                raise WrongHyperparamsKeys(
-                    hyperparams=hyperparams, hyperparams_class=hyperparams_class
-                ) from exc
+            return hyperparams_class()
         if isinstance(hyperparams, hyperparams_class):
             return hyperparams
         if isinstance(hyperparams, Mapping):
-            try:
-                return hyperparams_class(**hyperparams)
-            except (TypeError, ValueError, SyntaxError) as exc:
-                raise WrongHyperparamsKeys(
-                    hyperparams=hyperparams, hyperparams_class=hyperparams_class
-                ) from exc
+            return hyperparams_class(**hyperparams)
         raise WrongHyperparamsType(hyperparams=hyperparams, class_name=class_name)
     raise YouForgotTheHyperparams(class_name=class_name)
 

--- a/tests/test_datablob.py
+++ b/tests/test_datablob.py
@@ -368,16 +368,6 @@ class TestDataBlob(DataBlobTestCase):
         self.assertEqual(blob1.group_name, blob2.group_name)
         self.assertEqual(blob1.group_name, blob3.group_name)
 
-    def test_no_hyperparams(self):
-        """Test the error when a DataBlob has required hyperparams and we don't specify them."""
-        with self.assertRaises(sp.exceptions.WrongHyperparamsKeys):
-            MyDataBlobRequiredHyperparams()
-
-    def test_unnecessary_hyperparams(self):
-        """Test what happens when we pass unnecessary hyperparams to a DataBlob."""
-        with self.assertRaises(sp.exceptions.WrongHyperparamsKeys):
-            MyDataBlob(hyperparams=dict(z=3))
-
     def test_missing_hyperparams_class(self):
         """Test what happens when the hyperparams class itself is missing."""
         with self.assertRaises(sp.exceptions.YouForgotTheHyperparams):
@@ -1075,22 +1065,6 @@ class TestAppendDataBlob(unittest.TestCase):
                     append_value = append_tensor.numpy()
                     self.assertEqual(idx, append_tensor_idx)
                     self.assertEqual(parent_value, append_value)
-
-    def test_no_hyperparams(self):
-        """Test AppendDataBlob without hyperparams."""
-        parent = MyDataBlob(hyperparams=dict(a=1, b="hi"), secret="s1")
-        with self.assertRaises(sp.exceptions.WrongHyperparamsKeys):
-            MyAppendDataBlob(parent=parent, secret2="secret2")
-
-    def test_unnecessary_hyperparams(self):
-        """Test AppendDataBlob with unnecessary hyperparameters."""
-        parent = MyDataBlob(hyperparams=dict(a=1, b="hi"), secret="s1")
-        with self.assertRaises(sp.exceptions.WrongHyperparamsKeys):
-            MyAppendDataBlob(
-                parent=parent,
-                hyperparams=dict(coefficient=10, unnecessary=1),
-                secret2="secret2",
-            )
 
     def test_with_dataframe(self):
         """Test that an AppendDataBlob can inherit from a DataFrameDataBlob."""

--- a/tests/test_model_template.py
+++ b/tests/test_model_template.py
@@ -57,20 +57,6 @@ class TestModelTemplate(unittest.TestCase):
                     sp.dataclasses.asdict(model_template.hyperparams), dict(a=1, b="hi")
                 )
 
-    def test_no_hyperparams(self):
-        """
-        Test the error when a ModelTemplate has required hyperparams
-        and we don't specify them.
-        """
-        with self.assertRaises(sp.exceptions.WrongHyperparamsKeys):
-            MyModelTemplate()
-
-    def test_unnecessary_hyperparams(self):
-        """Test what happens when we pass unnecessary hyperparams to a ModelTemplate."""
-
-        with self.assertRaises(sp.exceptions.WrongHyperparamsKeys):
-            MyModelTemplate(hyperparams=dict(a=1, b="hi", c=3))
-
     def test_missing_hyperparams_class(self):
         """Test what happens when the hyperparams class itself is missing."""
         with self.assertRaises(sp.exceptions.YouForgotTheHyperparams):


### PR DESCRIPTION
Our existing code was swallowing other `ValueError` exceptions
raised in a `Hyperparams` dataclass `__post_init__()` method.

To remove the ambiguity, we're removing `WrongHyperparamsKeys`.