### PR TITLE
Don't require that dataclasses be `frozen`

### DIFF
--- a/scalarstop/dataclasses.py
+++ b/scalarstop/dataclasses.py
@@ -31,7 +31,7 @@ _FIELD_INITVAR = "_FIELD_INITVAR"
 # objects.  Also used to check if a class is a Data Class.
 _FIELDS = "__dataclass_fields__"
 
-dataclass = _python_dataclasses.dataclass(frozen=True)
+dataclass = _python_dataclasses.dataclass
 
 
 def is_dataclass(obj: Any) -> bool:

--- a/tests/test_hyperparams.py
+++ b/tests/test_hyperparams.py
@@ -1,0 +1,31 @@
+"""Unit tests for the hyperparams module."""
+import unittest
+
+import scalarstop as sp
+
+
+class TestHyperparams(unittest.TestCase):
+    """Unit tests for the Hyperparams dataclass."""
+
+    def test_hyperparams_are_not_frozen(self):
+        """
+        Test that hyperparams are not a frozen dataclass.
+
+        Frozen dataclasses cannot mutate themselves in
+        their ``__post_init__()`` method, and we want
+        to allow such mutations.
+        """
+
+        @sp.dataclass
+        class Hyperparams(sp.HyperparamsType):
+            """Test hyperparams."""
+
+            a: int
+            b: str
+
+            def __post_init__(self):
+                self.b = self.b + str(self.a)
+
+        hp = Hyperparams(a=1, b="hi")
+        self.assertEqual(hp.a, 1)
+        self.assertEqual(hp.b, "hi1")


### PR DESCRIPTION
Frozen dataclasses cannot mutate themselves in
their `__post_init__()` method, and we want
to allow such mutations.