### PR TITLE
Add `DataBlob.hyperparams_flat`, a property for accessing a "flattened" version of nested hyperparameters.

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -272,7 +272,7 @@ ignored-classes=optparse.Values,thread._local,_thread._local
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis). It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=sqlite3
+ignored-modules=sqlite3,alembic
 
 # Show a hint with possible names when a member name was not found. The aspect
 # of finding the hint is based on edit distance.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ numpy = "*"
 cloudpickle = "^1.6.0"
 SQLAlchemy = "^1.4.5"
 psycopg2-binary = "^2.8.6"
+alembic = "^1.7.1"
 log-with-context = "*"
 
 # These are optional dependencies installed

--- a/scalarstop/_attr_dict.py
+++ b/scalarstop/_attr_dict.py
@@ -1,0 +1,35 @@
+"""Tools for simulating dataclasses without having to specify all of the parameter types."""
+
+
+class AttrDict(dict):
+    """
+    A dictionary subclass that allows accessing dictionary keys as parameters.
+
+    This is useful for providing an interface similar to a
+    :py:class:`~scalarstop.hyperparams.HyperparamsType` instance,
+    but without having to know the keys and values ahead of time.
+
+    ``AttrDict`` subclasses :py:class:`dict` so it can be serialized
+    to JSON.
+
+    Examples:
+
+    >>> d = AttrDict(a=1, b=2)
+    >>> d
+    {'a': 1, 'b': 2}
+    >>> d["a"]
+    1
+    >>> d.a
+    1
+    >>> d["b"]
+    2
+    >>> d.b
+    2
+    """
+
+    def __getattribute__(self, key: str):
+        """Check if the key is in the dictionary. Otherwise treat the key as an attribute."""
+        try:
+            return dict.__getitem__(self, key)
+        except KeyError:
+            return dict.__getattribute__(self, key)

--- a/scalarstop/hyperparams.py
+++ b/scalarstop/hyperparams.py
@@ -3,6 +3,7 @@ Utilities for creating typed Python dataclasses for storing hyperparameters.
 """
 from typing import TYPE_CHECKING, Any, Dict, Mapping
 
+from scalarstop._attr_dict import AttrDict
 from scalarstop._naming import hash_id
 from scalarstop.dataclasses import asdict, is_dataclass
 from scalarstop.exceptions import WrongHyperparamsType, YouForgotTheHyperparams
@@ -60,7 +61,7 @@ def flatten_hyperparams(hyperparams: Any) -> Dict[str, Any]:
     Recursively flatten the hyperparams embedded
     in a :py:class:`NestedHyperparamsType` instance.
     """
-    return _flatten_hyperparams(enforce_dict(hyperparams))
+    return AttrDict(**_flatten_hyperparams(enforce_dict(hyperparams)))
 
 
 @dataclass  # pylint: disable=used-before-assignment

--- a/scalarstop/hyperparams.py
+++ b/scalarstop/hyperparams.py
@@ -45,6 +45,24 @@ def init_hyperparams(*, class_name: str, hyperparams, hyperparams_class) -> Any:
     raise YouForgotTheHyperparams(class_name=class_name)
 
 
+def _flatten_hyperparams(hp_dict):
+    parent_hp_dict = hp_dict.pop("parent", None)
+    if parent_hp_dict:
+        return {
+            **_flatten_hyperparams(parent_hp_dict["hyperparams"]),
+            **hp_dict,
+        }
+    return hp_dict
+
+
+def flatten_hyperparams(hyperparams: Any) -> Dict[str, Any]:
+    """
+    Recursively flatten the hyperparams embedded
+    in a :py:class:`NestedHyperparamsType` instance.
+    """
+    return _flatten_hyperparams(enforce_dict(hyperparams))
+
+
 @dataclass  # pylint: disable=used-before-assignment
 class HyperparamsType:
     """

--- a/tests/assertions.py
+++ b/tests/assertions.py
@@ -1,7 +1,7 @@
 """Testing utilities that we'll use throughout the project."""
 import os
 import unittest
-from typing import List
+from typing import Any, Dict, List
 
 import numpy as np
 import pandas as pd
@@ -50,6 +50,11 @@ def assert_hyperparams_are_equal(h1: sp.HyperparamsType, h2: sp.HyperparamsType)
     )
 
 
+def assert_hyperparams_flat_are_equal(h1: Dict[str, Any], h2: Dict[str, Any]):
+    """Assert the outputs of hyperparams_flat() are equal."""
+    assert_equal(h1, h2)
+
+
 def tfdata_as_list(tfdata: tf.data.Dataset) -> List[np.ndarray]:
     """Return a tf.data pipeline as a list of NumPy arrays."""
     return list(tfdata.as_numpy_iterator())
@@ -66,12 +71,18 @@ def assert_tfdatas_are_equal(d1: tf.data.Dataset, d2: tf.data.Dataset):
         assert np.array_equal(i1, i2)
 
 
+def assert_datablob_reprs_are_equal(blob1: sp.DataBlob, blob2: sp.DataBlob):
+    """Assert that DataBlob __repr__() methods return the same string."""
+    assert_equal(repr(blob1), repr(blob2))
+
+
 def assert_datablob_metadatas_are_equal(blob1: sp.DataBlob, blob2: sp.DataBlob):
     """Assert that datablob metadata is equal, but does not check DataFrames or Datasets."""
     assert_equal(repr(blob1), repr(blob2))
     assert_equal(blob1.name, blob2.name)
     assert_equal(blob1.group_name, blob2.group_name)
     assert_hyperparams_are_equal(blob1.hyperparams, blob2.hyperparams)
+    assert_hyperparams_flat_are_equal(blob1.hyperparams_flat, blob2.hyperparams_flat)
 
 
 def assert_datablob_dataframes_are_equal(

--- a/tests/test__attr_dict.py
+++ b/tests/test__attr_dict.py
@@ -1,0 +1,42 @@
+"""Unit tests for the scalarstop._attr_dict module."""
+import doctest
+import json
+import unittest
+
+from scalarstop import _attr_dict
+from scalarstop._attr_dict import AttrDict
+
+
+def load_tests(loader, tests, ignore):  # pylint: disable=unused-argument
+    """Have the unittest loader also run doctests."""
+    tests.addTests(doctest.DocTestSuite(_attr_dict))
+    return tests
+
+
+class TestAttrDict(unittest.TestCase):
+    """Unit tests for scalarstop._attr_dict.AttrDict."""
+
+    def test_simple(self):
+        """Test that AttrDict works."""
+        ad = AttrDict(a=1, b=2, clear=3, values=4)
+        self.assertEqual(ad.a, 1)
+        self.assertEqual(ad.b, 2)
+        self.assertEqual(ad.clear, 3)
+        self.assertEqual(ad.values, 4)
+
+    def test_keys_with_special_chars(self):
+        """
+        Test that AttrDict can have dictionary keys with special characters.
+
+        In this case, "special" characters refers to anything that
+        cannot be a key in a ``dict()`` expression.
+        """
+        ad = AttrDict(**{"blob-a": 1, "omg.wtf": 2})
+        self.assertEqual(ad["blob-a"], 1)
+        self.assertEqual(ad["omg.wtf"], 2)
+
+    def test_serialize_to_json(self):
+        """Test that we can serialize an AttrDict to JSON."""
+        ad = AttrDict(a=1, b=2, clear=3, values=4)
+        loaded = json.loads(json.dumps(ad))
+        self.assertEqual(ad, loaded)

--- a/tests/test_datablob.py
+++ b/tests/test_datablob.py
@@ -22,7 +22,9 @@ from tests.assertions import (
     assert_dataframes_are_equal,
     assert_directory,
     assert_hyperparams_are_equal,
+    assert_hyperparams_flat_are_equal,
     assert_tfdatas_are_equal,
+    tfdata_as_list,
     tfdata_get_first_shape_len,
 )
 
@@ -50,15 +52,21 @@ class MyDataBlob(sp.DataBlob):
 
     def set_training(self):
         """Set the training tfdata."""
-        return tf.data.Dataset.from_tensor_slices([1, 2, 3, 4, 5])
+        return tf.data.Dataset.from_tensor_slices([1, 2, 3, 4, 5]).map(
+            lambda x: x * self.hyperparams.a
+        )
 
     def set_validation(self):
         """Set the validation tfdata."""
-        return tf.data.Dataset.from_tensor_slices([6, 7, 8, 9, 10])
+        return tf.data.Dataset.from_tensor_slices([6, 7, 8, 9, 10]).map(
+            lambda x: x * self.hyperparams.a
+        )
 
     def set_test(self):
         """Set the test tfdata."""
-        return tf.data.Dataset.from_tensor_slices([11, 12, 13, 14, 15])
+        return tf.data.Dataset.from_tensor_slices([11, 12, 13, 14, 15]).map(
+            lambda x: x * self.hyperparams.a
+        )
 
 
 class MyDataBlobArbitraryRows(sp.DataBlob):
@@ -273,6 +281,51 @@ class MyAppendDataBlob(sp.AppendDataBlob):
         return tfdata.map(
             lambda row: row * self.hyperparams.coefficient,
         )
+
+
+class MyAppendDataBlobConflictA(sp.AppendDataBlob):
+    """
+    An AppendDataBlob whose hyperparam `a` is intended to
+    conflict with MyDataBlob.
+    """
+
+    @sp.dataclass
+    class Hyperparams(sp.AppendHyperparamsType):
+        """Hyperparams for MyAppendDataBlobConflictA."""
+
+        a: int
+        c: int
+        d: int
+
+    hyperparams: "MyAppendDataBlobConflictA.Hyperparams"
+
+    def _wrap_tfdata(self, tfdata: tf.data.Dataset) -> tf.data.Dataset:
+        """Multiply the input tf.data.Dataset by our `a` hyperparameter."""
+        return tfdata.map(lambda x: x * self.hyperparams.a)
+
+
+class MyAppendDataBlobConflictB(sp.AppendDataBlob):
+    """
+    An AppendDataBlob whose hyperparam `b` is intended to
+    conflict with MyDataBlob.
+
+    The hyperparam `c` is also meant to conflict with
+    MyAppendDataBlobConflictA.
+    """
+
+    @sp.dataclass
+    class Hyperparams(sp.AppendHyperparamsType):
+        """Hyperparams for MyAppendDataBlobConflictB."""
+
+        b: "str"
+        c: int
+        e: int
+
+    hyperparams: "MyAppendDataBlobConflictB.Hyperparams"
+
+    def _wrap_tfdata(self, tfdata: tf.data.Dataset) -> tf.data.Dataset:
+        """Multiply the input tf.data.Dataset by our `c` hyperparameter."""
+        return tfdata.map(lambda x: x * self.hyperparams.c)
 
 
 class MyAppendDataBlobNoHyperparams(sp.AppendDataBlob):
@@ -935,9 +988,7 @@ class Test_CacheDataBlob(DataBlobTestCase):
         cached = blob.cache(
             precache_training=True, precache_validation=True, precache_test=True
         )
-        self.assertEqual(blob.name, cached.name)
-        self.assertEqual(blob.group_name, cached.group_name)
-        self.assertEqual(blob.hyperparams, cached.hyperparams)
+        assert_datablob_metadatas_are_equal(blob, cached)
         # The training, validation, and test sets added 9 each. 9 + 18 brings us to 27.
         self.assertEqual(cached.count, 27)
         for subtype in ["training", "validation", "test"]:
@@ -983,6 +1034,11 @@ class Test_WithOptionsDataBlob(DataBlobTestCase):
         # Try setting the AutoShardPolicy to DATA.
         blob_with_options = blob.with_options(self.tf_options)
 
+        assert_hyperparams_are_equal(blob.hyperparams, blob_with_options.hyperparams)
+        assert_hyperparams_flat_are_equal(
+            blob.hyperparams_flat, blob_with_options.hyperparams_flat
+        )
+
         # Check that the sharding policy has been properly applied.
         for subtype in ["training", "validation", "test"]:
             with self.subTest(subtype):
@@ -999,20 +1055,24 @@ class Test_WithOptionsDataBlob(DataBlobTestCase):
         AUTO = tf.data.experimental.AutoShardPolicy.AUTO
         DATA = tf.data.experimental.AutoShardPolicy.DATA
         blob = MyDataBlob(hyperparams=dict(a=1, b="hi"), secret="s1")
-        blob_w_options = blob.with_options(
+        blob_with_options = blob.with_options(
             self.tf_options,
             validation=False,
         )
+        assert_hyperparams_are_equal(blob.hyperparams, blob_with_options.hyperparams)
+        assert_hyperparams_flat_are_equal(
+            blob.hyperparams_flat, blob_with_options.hyperparams_flat
+        )
         self.assertEqual(
-            blob_w_options.training.options().experimental_distribute.auto_shard_policy,
+            blob_with_options.training.options().experimental_distribute.auto_shard_policy,
             DATA,
         )
         self.assertEqual(
-            blob_w_options.validation.options().experimental_distribute.auto_shard_policy,
+            blob_with_options.validation.options().experimental_distribute.auto_shard_policy,
             AUTO,
         )
         self.assertEqual(
-            blob_w_options.test.options().experimental_distribute.auto_shard_policy,
+            blob_with_options.test.options().experimental_distribute.auto_shard_policy,
             DATA,
         )
 
@@ -1128,13 +1188,17 @@ class TestAppendDataBlob(unittest.TestCase):
 
     def assert_parentage(self, *, parent, append):
         """A basket of assertions for parent and child DataBlobs."""
-        # Check that we have embedded the parent data.
-        self.assertEqual(append.hyperparams.parent.name, parent.name)
-        self.assertEqual(append.hyperparams.parent.group_name, parent.group_name)
-        self.assertEqual(
-            sp.enforce_dict(append.parent.hyperparams),
-            sp.enforce_dict(parent.hyperparams),
-        )
+        # Check append.parent points to parent.
+        assert_datablob_metadatas_are_equal(parent, append.parent)
+        assert_datablobs_tfdatas_are_equal(parent, append.parent)
+
+        # Check that append.hyperparams contains the parent's hyperparams.
+        self.assertEqual(parent.name, append.hyperparams.parent.name)
+        self.assertEqual(parent.group_name, append.hyperparams.parent.group_name)
+
+        # Check that we have embedded the parent's hyperparams.
+        assert_hyperparams_are_equal(parent.hyperparams, append.parent.hyperparams)
+
         # Check that our AppendDataset has a unique name
         # that is different from the parent.
         self.assertTrue(append.name != parent.name)
@@ -1149,6 +1213,11 @@ class TestAppendDataBlob(unittest.TestCase):
         """
         parent = MyDataBlob(hyperparams=dict(a=1, b="hi"), secret="s1")
         append = sp.AppendDataBlob(parent=parent)
+        self.assert_parentage(parent=parent, append=append)
+        assert_hyperparams_flat_are_equal(
+            parent.hyperparams_flat, append.hyperparams_flat
+        )
+
         with self.assertRaises(sp.exceptions.IsNotImplemented):
             append.training  # pylint: disable=pointless-statement
         with self.assertRaises(sp.exceptions.IsNotImplemented):
@@ -1159,13 +1228,17 @@ class TestAppendDataBlob(unittest.TestCase):
     def test_success(self):
         """Test that AppendDataBlob works."""
         coefficient = 10
-        parent = MyDataBlob(hyperparams=dict(a=1, b="hi"), secret="s1")
+        append_hyperparams = dict(coefficient=coefficient)
+        parent_hyperparams = dict(a=1, b="hi")
+        parent = MyDataBlob(hyperparams=parent_hyperparams, secret="s1")
         append = MyAppendDataBlob(
-            parent=parent, hyperparams=dict(coefficient=coefficient), secret2="secret2"
+            parent=parent, hyperparams=append_hyperparams, secret2="secret2"
         )
         # Assert the basics.
         self.assert_parentage(parent=parent, append=append)
-
+        assert_hyperparams_flat_are_equal(
+            dict(**parent_hyperparams, **append_hyperparams), append.hyperparams_flat
+        )
         self.assertEqual(
             set(sp.enforce_dict(append.hyperparams)), set(["parent", "coefficient"])
         )
@@ -1182,11 +1255,15 @@ class TestAppendDataBlob(unittest.TestCase):
 
     def test_success_no_additional_hyperparams(self):
         """Test that AppendDataBlob works when we have no additional hyperparams to add."""
-        parent = MyDataBlob(hyperparams=dict(a=1, b="hi"), secret="s1")
+        parent_hyperparams = dict(a=1, b="hi")
+        parent = MyDataBlob(hyperparams=parent_hyperparams, secret="s1")
         append = MyAppendDataBlobNoHyperparams(parent=parent)
 
         # Assert the basics.
         self.assert_parentage(parent=parent, append=append)
+        assert_hyperparams_flat_are_equal(
+            parent.hyperparams_flat, append.hyperparams_flat
+        )
 
         # Assert that we have no other hyperparams.
         self.assertEqual(set(sp.enforce_dict(append.hyperparams)), set(["parent"]))
@@ -1218,13 +1295,20 @@ class TestAppendDataBlob(unittest.TestCase):
 
     def test_batch(self):
         """Test batching on AppendDataBlob."""
-        parent = MyDataBlob(hyperparams=dict(a=1, b="hi"), secret="s1")
+        append_hyperparams = dict(coefficient=10)
+        parent_hyperparams = dict(a=1, b="hi")
+        parent = MyDataBlob(hyperparams=parent_hyperparams, secret="s1")
         append = MyAppendDataBlob(
             parent=parent,
-            hyperparams=dict(coefficient=10),
+            hyperparams=append_hyperparams,
             secret2="secret2",
         )
+        self.assert_parentage(parent=parent, append=append)
         batched = append.batch(2)
+        self.assert_parentage(parent=parent, append=batched)
+        assert_hyperparams_flat_are_equal(
+            dict(**parent_hyperparams, **append_hyperparams), batched.hyperparams_flat
+        )
         for subtype in ["training", "validation", "test"]:
             with self.subTest(subtype):
                 lst = list(getattr(batched, subtype))
@@ -1291,6 +1375,43 @@ class TestAppendDataBlob(unittest.TestCase):
             )
             assert_datablob_metadatas_are_equal(append, append_loaded)
             assert_datablobs_tfdatas_are_equal(append, append_loaded)
+
+    def test_hyperparams_flat_works(self):
+        """
+        Assert that the hyperparams_flat() property flattens
+        nested hyperparams from AppendDataBlobs.
+        """
+        parent = MyDataBlob(hyperparams=dict(a=2, b="hi"), secret="s1")
+        child = MyAppendDataBlobConflictA(
+            parent=parent, hyperparams=dict(a=5, c=3, d=4)
+        )
+        grandchild = MyAppendDataBlobConflictB(
+            parent=child, hyperparams=dict(b="lol", c=6, e=7)
+        )
+
+        self.assert_parentage(parent=parent, append=child)
+        self.assert_parentage(parent=child, append=grandchild)
+        self.assert_parentage(parent=parent, append=grandchild.parent)
+
+        self.assertEqual(
+            grandchild.hyperparams.parent.hyperparams.parent.name, parent.name
+        )
+        self.assertEqual(
+            grandchild.hyperparams.parent.hyperparams.parent.group_name,
+            parent.group_name,
+        )
+        assert_hyperparams_are_equal(
+            grandchild.hyperparams.parent.hyperparams.parent.hyperparams,
+            parent.hyperparams,
+        )
+
+        self.assertEqual(parent.hyperparams_flat, dict(a=2, b="hi"))
+        self.assertEqual(child.hyperparams_flat, dict(a=5, b="hi", c=3, d=4))
+        self.assertEqual(grandchild.hyperparams_flat, dict(a=5, b="lol", d=4, c=6, e=7))
+
+        self.assertEqual([2, 4, 6, 8, 10], tfdata_as_list(parent.training))
+        self.assertEqual([10, 20, 30, 40, 50], tfdata_as_list(child.training))
+        self.assertEqual([60, 120, 180, 240, 300], tfdata_as_list(grandchild.training))
 
 
 class TestDataBlobSaveLoadVersions(unittest.TestCase):

--- a/tests/test_datablob.py
+++ b/tests/test_datablob.py
@@ -1409,6 +1409,18 @@ class TestAppendDataBlob(unittest.TestCase):
         self.assertEqual(child.hyperparams_flat, dict(a=5, b="hi", c=3, d=4))
         self.assertEqual(grandchild.hyperparams_flat, dict(a=5, b="lol", d=4, c=6, e=7))
 
+        self.assertEqual(parent.hyperparams_flat.a, 2)
+        self.assertEqual(parent.hyperparams_flat.b, "hi")
+        self.assertEqual(child.hyperparams_flat.a, 5)
+        self.assertEqual(child.hyperparams_flat.b, "hi")
+        self.assertEqual(child.hyperparams_flat.c, 3)
+        self.assertEqual(child.hyperparams_flat.d, 4)
+        self.assertEqual(grandchild.hyperparams_flat.a, 5)
+        self.assertEqual(grandchild.hyperparams_flat.b, "lol")
+        self.assertEqual(grandchild.hyperparams_flat.c, 6)
+        self.assertEqual(grandchild.hyperparams_flat.d, 4)
+        self.assertEqual(grandchild.hyperparams_flat.e, 7)
+
         self.assertEqual([2, 4, 6, 8, 10], tfdata_as_list(parent.training))
         self.assertEqual([10, 20, 30, 40, 50], tfdata_as_list(child.training))
         self.assertEqual([60, 120, 180, 240, 300], tfdata_as_list(grandchild.training))

--- a/tests/test_train_store.py
+++ b/tests/test_train_store.py
@@ -70,6 +70,7 @@ class TrainStoreUnits:  # pylint: disable=no-member
             [
                 "group_name",
                 "hyperparams",
+                "hyperparams_flat",
                 "last_modified",
                 "name",
             ],
@@ -374,6 +375,7 @@ class TrainStoreIntegration:  # pylint: disable=no-member
             [
                 "datablob_group_name",
                 "datablob_hyperparams",
+                "datablob_hyperparams_flat",
                 "datablob_name",
                 "model_class_name",
                 "model_epoch_metrics",

--- a/tests/test_train_store_database_migrations.py
+++ b/tests/test_train_store_database_migrations.py
@@ -57,6 +57,7 @@ class TestTrainStoreMigrations(unittest.TestCase):
                             [
                                 "datablob_group_name",
                                 "datablob_hyperparams",
+                                "datablob_hyperparams_flat",
                                 "datablob_last_modified",
                                 "datablob_name",
                             ],

--- a/tests/test_train_store_database_migrations.py
+++ b/tests/test_train_store_database_migrations.py
@@ -10,6 +10,7 @@ import unittest
 from sqlalchemy import inspect
 
 import scalarstop as sp
+from tests.fixtures import requires_sqlite_json
 
 
 def get_column_names(inspector, table_name):
@@ -20,6 +21,7 @@ def get_column_names(inspector, table_name):
     return sorted([col["name"] for col in inspector.get_columns(table_name)])
 
 
+@requires_sqlite_json
 class TestTrainStoreMigrations(unittest.TestCase):
     """Tests for the TrainStore's automatic migration features."""
 


### PR DESCRIPTION
When we create a structure of nested `AppendDataBlobs`,
it becomes harder to access values in a nested
structure of `Hyperparams` objects.

the `hyperparams_flat` property returns a Python
dictionary of all hyperparameter keys in an
`AppendDataBlob`'s lineage.