### PR TITLE
Fix querying for `MOdelTemplate` and `DataBlob` group names in `TrainStore.list_models()`

### DIFF
--- a/scalarstop/train_store.py
+++ b/scalarstop/train_store.py
@@ -878,11 +878,11 @@ class TrainStore:
             raise _datablob_value_error
         if datablob_name:
             where_conditions.append(
-                self.table.model.c.datablob_name.in_(_enforce_list(datablob_name))
+                self.table.datablob.c.datablob_name.in_(_enforce_list(datablob_name))
             )
         elif datablob_group_name:
             where_conditions.append(
-                self.table.model.c.datablob_group_name.in_(
+                self.table.datablob.c.datablob_group_name.in_(
                     _enforce_list(datablob_group_name)
                 )
             )
@@ -891,13 +891,13 @@ class TrainStore:
             raise _model_template_value_error
         if model_template_name:
             where_conditions.append(
-                self.table.model.c.model_template_name.in_(
+                self.table.model_template.c.model_template_name.in_(
                     _enforce_list(model_template_name)
                 )
             )
         elif model_template_group_name:
             where_conditions.append(
-                self.table.model.c.model_template_group_name.in_(
+                self.table.model_template.c.model_template_group_name.in_(
                     _enforce_list(model_template_group_name)
                 )
             )

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -50,8 +50,81 @@ class MyDataBlob(sp.DataBlob):
         return self._tfdata()
 
 
+class MyDataBlob2(MyDataBlob):
+    """Another DataBlob to test different group names."""
+
+    @sp.dataclass
+    class Hyperparams:
+        """Hyperparams."""
+
+        rows: int
+        cols: int
+
+    def _tfdata(self):
+        """Generate example data."""
+        x = tf.random.uniform(
+            shape=(self.hyperparams.rows, self.hyperparams.cols), dtype=tf.float32
+        )
+        y = tf.random.uniform(shape=(self.hyperparams.rows,), dtype=tf.float32)
+        return tf.data.Dataset.zip(
+            (
+                tf.data.Dataset.from_tensor_slices(x),
+                tf.data.Dataset.from_tensor_slices(y),
+            )
+        )
+
+    def set_training(self):
+        return self._tfdata()
+
+    def set_validation(self):
+        return self._tfdata()
+
+    def set_test(self):
+        return self._tfdata()
+
+
 class MyModelTemplate(sp.ModelTemplate):
     """Example model template."""
+
+    @sp.dataclass
+    class Hyperparams:
+        """Hyperparams."""
+
+        layer_1_units: int
+        optimizer: str = "adam"
+        loss: str = "binary_crossentropy"
+
+    def new_model(self):
+        """Set a model."""
+        model = tf.keras.Sequential(
+            layers=[
+                tf.keras.layers.Dense(
+                    units=self.hyperparams.layer_1_units,
+                    kernel_initializer="zeros",
+                    bias_initializer="zeros",
+                ),
+                tf.keras.layers.Dense(
+                    units=1,
+                    activation="sigmoid",
+                    kernel_initializer="zeros",
+                    bias_initializer="zeros",
+                ),
+            ]
+        )
+        model.compile(
+            optimizer=self.hyperparams.optimizer,
+            loss=self.hyperparams.loss,
+            metrics=[
+                tf.keras.metrics.BinaryAccuracy(name="binary_accuracy"),
+                tf.keras.metrics.Precision(name="precision"),
+                tf.keras.metrics.Recall(name="recall"),
+            ],
+        )
+        return model
+
+
+class MyModelTemplate2(MyModelTemplate):
+    """Another ModelTemplate to test different group names."""
 
     @sp.dataclass
     class Hyperparams:


### PR DESCRIPTION
Previously, `TrainStore.list_models()` threw an error if you tried
to filter on `datablob_group_name` or `model_template_group_name`.