### PR TITLE
Bump TensorFlow dependency to 2.5.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ ScalarStop is a Python package that requires Python 3.8 or newer.
 Currently, ScalarStop only supports tracking
 `tf.data.Dataset <https://www.tensorflow.org/api_docs/python/tf/data/Dataset>`_
 datasets and `tf.keras.Model <https://www.tensorflow.org/api_docs/python/tf/keras/Model>`_
-models. As such, ScalarStop requires TensorFlow 2.3.0 or newer.
+models. As such, ScalarStop requires TensorFlow 2.5.0 or newer.
 
 We encourage anybody that would like to add support for other
 machine learning frameworks to ScalarStop. :)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -49,7 +49,7 @@ ScalarStop is a Python package that requires Python 3.8 or newer.
 
 Currently, ScalarStop only supports tracking :py:class:`tf.data.Dataset`
 datasets and :py:class:`tf.keras.Model` models. As such, ScalarStop
-requires TensorFlow 2.3.0 or newer.
+requires TensorFlow 2.5.0 or newer.
 
 We encourage anybody that would like to add support for other
 machine learning frameworks to ScalarStop. :)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,8 @@ log-with-context = "*"
 
 # These are optional dependencies installed
 # with pip extras. Seee the `tool.poetry.extras` section for more.
-tensorflow = { version = ">=2.3.0", optional = true }
-tensorflow-gpu = { version = ">=2.3.0", optional = true }
+tensorflow = { version = ">=2.5", optional = true }
+tensorflow-gpu = { version = ">=2.5", optional = true }
 
 [tool.poetry.dev-dependencies]
 # dev-dependencies does not include dependencies


### PR DESCRIPTION
TensorFlow 2.5.0 is the oldest version supported by
Python 3.9. We are bumping our dependency version so that
Poetry's dependency resolver doesn't unnecessarily crash
on Python 3.9.