### PR TITLE
Add `TFConfig` to query the `"TF_CONFIG"` environment variable

### DIFF
--- a/scalarstop/__init__.py
+++ b/scalarstop/__init__.py
@@ -6,6 +6,7 @@ from scalarstop import (
     model,
     model_template,
     pickle,
+    tf_config,
     train_store,
 )
 
@@ -25,3 +26,4 @@ from scalarstop.hyperparams import HyperparamsType  # isort:skip
 from scalarstop.hyperparams import AppendHyperparamsType  # isort:skip
 from scalarstop.hyperparams import NestedHyperparamsType  # isort:skip
 from scalarstop.hyperparams import enforce_dict  # isort:skip
+from scalarstop.tf_config import TFConfig  # isort:skip

--- a/scalarstop/tf_config.py
+++ b/scalarstop/tf_config.py
@@ -1,0 +1,102 @@
+"""Helpers for TensorFlow's ``"TF_CONFIG"`` environment variable."""
+import json
+import os
+from typing import Any, Dict, Optional
+
+
+class TFConfig:
+    """
+    A helper object for querying the TensorFlow configuration in the
+    ``"TF_CONFIG"`` environment variable.
+    """
+
+    def __init__(self, *, tf_config_str: str = ""):
+        """
+        Args:
+            tf_config_str: A string containing a value for the
+                ``"TF_CONFIG"`` environment variable. This argument
+                is typically used for testing.
+        """
+        if not tf_config_str:
+            tf_config_str = os.environ.get("TF_CONFIG", "{}")
+        self._tf_config = json.loads(tf_config_str)
+        task = self._tf_config.get("task", {})
+        self._task_type = task.get("type")
+        self._task_index = task.get("index", 0)
+        self._is_chief = (
+            self._task_type is None
+            or self._task_type == "chief"
+            or (self._task_type == "worker" and self._task_index == 0)
+        )
+
+    @property
+    def to_dict(self) -> Dict[str, Any]:
+        """Returns a Python dictionary containing a ``"TF_CONFIG"`` configuration."""
+        return self._tf_config
+
+    def num_nodes(self, task_type: str) -> int:
+        """
+        Returns the number of nodes belonging to the task type.
+
+        Possible task types include:
+         * ``"chief"``
+         * ``"worker"``
+         * ``"ps"``
+         * ``"evaluator"``
+
+        Or you can pass ``task_type = "ALL"`` to count tasks of all types.
+
+        Args:
+            task_type: The task type for a worker.
+
+        Returns:
+            Returns the number of nodes for each type.
+        """
+        if task_type == "all":
+            return sum(
+                [
+                    len(nodes_by_type)
+                    for nodes_by_type in self._tf_config.get("cluster", {}).values()
+                ]
+            )
+        return len(self._tf_config.get("cluster", {}).get(task_type, ()))
+
+    @property
+    def task_type(self) -> Optional[str]:
+        """
+        Returns the current process's task type.
+
+        Possible task types include:
+         * ``None``
+         * ``"chief"``
+         * ``"worker"``
+         * ``"ps"``
+         * ``"evaluator"``
+        """
+        return self._task_type
+
+    @property
+    def task_index(self) -> int:
+        """
+        Returns the current process's task index.
+
+        The task index is a value between ``0`` and ``n-1``,
+        where ``n`` is the number of task processes in your
+        TensorFlow cluster.
+
+        This returns ``0`` if the ``"TF_CONFIG"`` environment
+        variable is not configured.
+        """
+        return self._task_index
+
+    @property
+    def is_chief(self) -> bool:
+        """
+        Returns ``True`` if the current process is the chief node in the cluster.
+
+        This method will also return ``True`` if the ``"TF_CONFIG"``
+        environment variable is not configured, as that would suggest
+        that this process the chief node--and the *only* node--in
+        the cluster.
+        """
+        return self._is_chief

--- a/tests/test_tf_config.py
+++ b/tests/test_tf_config.py
@@ -1,0 +1,136 @@
+"""
+Test the scalarstop.tf_config module.
+"""
+import json
+import unittest
+
+import scalarstop as sp
+
+
+class TestTFConfig(unittest.TestCase):
+    """
+    Unit tests for sp.TFConfig.
+    """
+
+    def test_env_var_is_missing_1(self):
+        """
+        Test our default values for when TF_CONFIG is missing.
+        """
+        cfg_str = "{}"
+        cfg = sp.TFConfig(tf_config_str=cfg_str)
+        self.assertEqual(cfg.to_dict, {})
+        self.assertEqual(cfg.num_nodes("all"), 0)
+        self.assertEqual(cfg.num_nodes("worker"), 0)
+        self.assertEqual(cfg.num_nodes("ps"), 0)
+        self.assertEqual(cfg.task_type, None)
+        self.assertEqual(cfg.task_index, 0)
+        self.assertTrue(cfg.is_chief)
+
+    def test_env_var_is_missing_2(self):
+        """
+        Test our default values for when TF_CONFIG is missing.
+        """
+        cfg_str = ""
+        cfg = sp.TFConfig(tf_config_str=cfg_str)
+        self.assertEqual(cfg.to_dict, {})
+        self.assertEqual(cfg.num_nodes("all"), 0)
+        self.assertEqual(cfg.num_nodes("worker"), 0)
+        self.assertEqual(cfg.num_nodes("ps"), 0)
+        self.assertEqual(cfg.task_type, None)
+        self.assertEqual(cfg.task_index, 0)
+        self.assertTrue(cfg.is_chief)
+
+    def test_parameter_server_1(self):
+        """
+        Test a parameter server TF_CONFIG where the current node
+        is not the chief.
+        """
+        cfg_str = json.dumps(
+            {
+                "cluster": {
+                    "worker": ["host1:port", "host2:port", "host3:port"],
+                    "ps": ["host4:port", "host5:port"],
+                },
+                "task": {"type": "worker", "index": 1},
+            }
+        )
+        cfg = sp.TFConfig(tf_config_str=cfg_str)
+        self.assertEqual(cfg.num_nodes("all"), 5)
+        self.assertEqual(cfg.num_nodes("worker"), 3)
+        self.assertEqual(cfg.num_nodes("ps"), 2)
+        self.assertEqual(cfg.task_type, "worker")
+        self.assertEqual(cfg.task_index, 1)
+        self.assertFalse(cfg.is_chief)
+
+    def test_parameter_server_2(self):
+        """
+        Test a parameter server TF_CONFIG where the current node
+        is the chief.
+        """
+        cfg_str = json.dumps(
+            {
+                "cluster": {
+                    "chief": ["host1:port"],
+                    "ps": ["host2:port"],
+                    "worker": [
+                        "host3:port",
+                        "host4:port",
+                    ],
+                },
+                "environment": "cloud",
+                "task": {
+                    "cloud": "...",
+                    "index": 0,
+                    "trial": "1",
+                    "type": "worker",
+                },
+            }
+        )
+        cfg = sp.TFConfig(tf_config_str=cfg_str)
+        self.assertEqual(cfg.num_nodes("all"), 4)
+        self.assertEqual(cfg.num_nodes("chief"), 1)
+        self.assertEqual(cfg.num_nodes("worker"), 2)
+        self.assertEqual(cfg.num_nodes("ps"), 1)
+        self.assertEqual(cfg.task_type, "worker")
+        self.assertEqual(cfg.task_index, 0)
+        self.assertTrue(cfg.is_chief)
+
+    def test_worker_1(self):
+        """
+        Test a worker TF_CONFIG where the current node
+        is the chief.
+        """
+        cfg_str = json.dumps(
+            {
+                "cluster": {"worker": ["host1:port", "host2:port"]},
+                "task": {"type": "worker", "index": 0},
+            }
+        )
+        cfg = sp.TFConfig(tf_config_str=cfg_str)
+        self.assertEqual(cfg.num_nodes("all"), 2)
+        self.assertEqual(cfg.num_nodes("chief"), 0)
+        self.assertEqual(cfg.num_nodes("worker"), 2)
+        self.assertEqual(cfg.num_nodes("ps"), 0)
+        self.assertEqual(cfg.task_type, "worker")
+        self.assertEqual(cfg.task_index, 0)
+        self.assertTrue(cfg.is_chief)
+
+    def test_worker_2(self):
+        """
+        Test a worker TF_CONFIG where the current node is not
+        the chief.
+        """
+        cfg_str = json.dumps(
+            {
+                "cluster": {"worker": ["host1:port", "host2:port"]},
+                "task": {"type": "worker", "index": 1},
+            }
+        )
+        cfg = sp.TFConfig(tf_config_str=cfg_str)
+        self.assertEqual(cfg.num_nodes("all"), 2)
+        self.assertEqual(cfg.num_nodes("chief"), 0)
+        self.assertEqual(cfg.num_nodes("worker"), 2)
+        self.assertEqual(cfg.num_nodes("ps"), 0)
+        self.assertEqual(cfg.task_type, "worker")
+        self.assertEqual(cfg.task_index, 1)
+        self.assertFalse(cfg.is_chief)


### PR DESCRIPTION
The `TFConfig` class makes it easy to arrange ScalarStop
model training jobs with multi-worker `tf.distribute` strategies.