### PR TITLE
Log `steps_per_epoch` and `validation_steps_per_epoch` to the `TrainStore`

### DIFF
--- a/scalarstop/_keras_callbacks.py
+++ b/scalarstop/_keras_callbacks.py
@@ -50,6 +50,8 @@ class EpochCallback(tf.keras.callbacks.Callback):
         *,
         scalarstop_model,
         logger,
+        steps_per_epoch: Optional[int] = None,
+        validation_steps_per_epoch: Optional[int] = None,
         models_directory: Optional[str] = None,
         train_store=None,
         log_epochs: bool = False,
@@ -60,6 +62,8 @@ class EpochCallback(tf.keras.callbacks.Callback):
         self._train_store = train_store
         self._log_epochs = log_epochs
         self._logger = logger
+        self._steps_per_epoch = steps_per_epoch
+        self._validation_steps_per_epoch = validation_steps_per_epoch
 
     def on_epoch_end(  # pylint: disable=signature-differs
         self, epoch: int, logs: Dict[str, Any]
@@ -92,6 +96,8 @@ class EpochCallback(tf.keras.callbacks.Callback):
                 epoch_num=self._scalarstop_model.current_epoch,
                 model_name=self._scalarstop_model.name,
                 metrics=float_logs,
+                steps_per_epoch=self._steps_per_epoch,
+                validation_steps_per_epoch=self._validation_steps_per_epoch,
                 ignore_existing=True,
             )
 

--- a/scalarstop/model.py
+++ b/scalarstop/model.py
@@ -554,6 +554,8 @@ class KerasModel(Model):
                 EpochCallback(
                     scalarstop_model=self,
                     logger=logger or _LOGGER,
+                    steps_per_epoch=steps_per_epoch,
+                    validation_steps_per_epoch=validation_steps_per_epoch,
                     models_directory=models_directory,
                     log_epochs=log_epochs,
                     train_store=train_store,

--- a/tests/test_train_store_database_migrations.py
+++ b/tests/test_train_store_database_migrations.py
@@ -101,5 +101,7 @@ class TestTrainStoreMigrations(unittest.TestCase):
                                 "model_epoch_metrics",
                                 "model_epoch_num",
                                 "model_name",
+                                "steps_per_epoch",
+                                "validation_steps_per_epoch",
                             ],
                         )


### PR DESCRIPTION
The `TrainStore` logs per-epoch metrics, but previously did not log whether
the size of an individual epoch was changed with the `steps_per_epoch`
or `validation_steps_per_epoch` flags.