### PR TITLE
Enable the `experimental_custom_gradients` option when saving Keras models

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,8 @@ log-with-context = "*"
 
 # These are optional dependencies installed
 # with pip extras. Seee the `tool.poetry.extras` section for more.
-tensorflow = { version = ">=2.5", optional = true }
-tensorflow-gpu = { version = ">=2.5", optional = true }
+tensorflow = { version = ">=2.6", optional = true }
+tensorflow-gpu = { version = ">=2.6", optional = true }
 
 [tool.poetry.dev-dependencies]
 # dev-dependencies does not include dependencies

--- a/scalarstop/model.py
+++ b/scalarstop/model.py
@@ -432,6 +432,16 @@ class KerasModel(Model):
         return 0
 
     def save(self, models_directory: str) -> None:
+        # The experimental_custom_gradients save option is only available
+        # on TensorFlow 2.6.0 and newer.
+        try:
+            save_options = (
+                tf.saved_model.SaveOptions(  # pylint: disable=unexpected-keyword-arg
+                    experimental_custom_gradients=True
+                )
+            )
+        except TypeError:
+            save_options = None
         model_path = os.path.join(models_directory, self.name)
         try:
             self._model.save(
@@ -439,6 +449,7 @@ class KerasModel(Model):
                 overwrite=True,
                 include_optimizer=True,
                 save_format="tf",
+                options=save_options,
             )
             history_path = os.path.join(model_path, _HISTORY_FILENAME)
             with open(history_path, "w", encoding="utf-8") as fp:


### PR DESCRIPTION
This enables saving custom TensorFlow gradients to the serialized
TensorFlow SavedModel format.

This is a revival of the previously-closed PR https://github.com/scalarstop/scalarstop/pull/19 .