### PR TITLE
Allow the user to specify whether they want psycopg2 or psycopg2-binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,12 +18,12 @@ rm-venv:
 
 install:
 	$(POETRY) update
-	$(POETRY) install --extras=tensorflow
+	$(POETRY) install --extras=tensorflow --extras=psycopg2-binary
 	$(POETRY) run pip install -r .readthedocs-requirements.txt
 
 install-gpu:
 	$(POETRY) update
-	$(POETRY) install --extras=tensorflow-gpu
+	$(POETRY) install --extras=tensorflow-gpu --extras=psycopg2-binary
 	$(POETRY) run pip install -r .readthedocs-requirements.txt
 
 fmt:

--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,9 @@ Installation
 
 ScalarStop is `available on PyPI <https://pypi.org/project/scalarstop/>`_.
 
+Selecting a TensorFlow package variant
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 If you are using TensorFlow on a CPU, you can install ScalarStop with the command:
 
 .. code:: bash
@@ -41,6 +44,24 @@ If you are using TensorFlow with GPUs, you can install ScalarStop with the comma
 .. code:: bash
 
     python3 -m pip install scalarstop[tensorflow-gpu]
+
+Selecting a PostgreSQL psycopg2 package variant
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you intend to use ScalarStop with PostgreSQL, you should also
+install either `psycopg2-binary <https://pypi.org/project/psycopg2-binary/>`_
+(`which works out of the box <https://www.psycopg.org/docs/install.html#psycopg-vs-psycopg-binary>`_)
+or `psycopg2 <https://pypi.org/project/psycopg2/>`_ (which you compile from source).
+
+Therefore, your installation command could look like either:
+
+.. code:: bash
+
+    python3 -m pip install scalarstop[tensorflow,psycopg2]
+    python3 -m pip install scalarstop[tensorflow,psycopg2-binary]
+    python3 -m pip install scalarstop[tensorflow-gpu,psycopg2]
+    python3 -m pip install scalarstop[tensorflow-gpu,psycopg2-binary]
+
 
 Development
 -----------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,25 +12,26 @@ repository = "https://github.com/scalarstop/scalarstop"
 python = "^3.8"
 pandas = "*"
 numpy = "*"
-cloudpickle = "^1.6.0"
-SQLAlchemy = "^1.4.5"
-psycopg2-binary = "^2.8.6"
-alembic = "^1.7.1"
+cloudpickle = "^2.0"
+SQLAlchemy = "^1.4"
+alembic = "^1.7"
 log-with-context = "*"
 
 # These are optional dependencies installed
 # with pip extras. Seee the `tool.poetry.extras` section for more.
 tensorflow = { version = ">=2.6", optional = true }
 tensorflow-gpu = { version = ">=2.6", optional = true }
+psycopg2 = { version = "^2.9.3", optional = true }
+psycopg2-binary = { version = "^2.9.3", optional = true }
 
 [tool.poetry.dev-dependencies]
 # dev-dependencies does not include dependencies
 # for generating docs. they are stored in .readthedocs-requirements.txt
 pytest = "^5.2"
-black = "^20.8b1"
-isort = "^5.8.0"
-pylint = "^2.10.2"
-mypy = "^0.812"
+pylint = "^2.12.2"
+mypy = "^0.941"
+black = "^22.1.0"
+isort = "^5.10.1"
 coverage = "^5.5"
 jupyter = "^1.0.0"
 
@@ -39,6 +40,8 @@ jupyter = "^1.0.0"
 [tool.poetry.extras]
 tensorflow = ["tensorflow"]
 tensorflow-gpu = ["tensorflow-gpu"]
+psycopg2 = ["psycopg2"]
+psycopg2-binary = ["psycopg2-binary"]
 
 [tool.black]
 target-version = ['py38']


### PR DESCRIPTION
This commit is a breaking change for the installation process.
Instead of automatically installing psycopg2-binary, we provide
installation of either psycopg2 or psycopg2 using pip/poetry "extras".