### PR TITLE
Tweak GitHub Actions caching

### DIFF
--- a/.github/workflows/test-mac.yml
+++ b/.github/workflows/test-mac.yml
@@ -23,6 +23,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - uses: actions/setup-python@v2
+      id: setup-python
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -35,9 +36,9 @@ jobs:
       uses: actions/cache@v2
       with:
         path: .venv
-        key: ${{ runner.os }}-python-${{ matrix.python-version }}-poetry-${{ hashFiles('**/poetry.lock') }}
+        key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-pyproject-${{ hashFiles('**/pyproject.toml') }}
         restore-keys: |
-          ${{ runner.os }}-python-${{ matrix.python-version }}-poetry-
+          ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-pyproject-
 
     - name: Install the package
       run: make install

--- a/.github/workflows/test-ubuntu.yml
+++ b/.github/workflows/test-ubuntu.yml
@@ -33,6 +33,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - uses: actions/setup-python@v2
+      id: setup-python
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -45,9 +46,9 @@ jobs:
       uses: actions/cache@v2
       with:
         path: .venv
-        key: ${{ runner.os }}-python-${{ matrix.python-version }}-poetry-${{ hashFiles('**/poetry.lock') }}
+        key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-pyproject-${{ hashFiles('**/pyproject.toml') }}
         restore-keys: |
-          ${{ runner.os }}-python-${{ matrix.python-version }}-poetry-
+          ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-pyproject-
 
     - name: Install the package
       run: make install

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -23,6 +23,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - uses: actions/setup-python@v2
+      id: setup-python
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -35,9 +36,9 @@ jobs:
       uses: actions/cache@v2
       with:
         path: .venv
-        key: ${{ runner.os }}-python-${{ matrix.python-version }}-poetry-${{ hashFiles('**/poetry.lock') }}
+        key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-pyproject-${{ hashFiles('**/pyproject.toml') }}
         restore-keys: |
-          ${{ runner.os }}-python-${{ matrix.python-version }}-poetry-
+          ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-pyproject-
 
     - name: Install the package
       run: make install


### PR DESCRIPTION
Now we precisely define cache keys based on the exact Python version and a hash of the pyproject.toml file.