### PR TITLE
Enable overwriting KerasModels.

### DIFF
--- a/scalarstop/model.py
+++ b/scalarstop/model.py
@@ -496,7 +496,7 @@ class KerasModel(Model):
         try:
             self._model.save(
                 filepath=model_epoch_path,
-                overwrite=False,
+                overwrite=True,
                 include_optimizer=True,
                 save_format="tf",
                 options=save_options,


### PR DESCRIPTION
This is necessary behavior in certain cases
where the model epoch directory already exists on the
filesystem and we are certain that we want to overwrite
it with a newer and more correct model.
